### PR TITLE
Update to use latest Python 3 version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3
 
 ARG command="--version"
 


### PR DESCRIPTION
Actualizar a Python 3

La última versión de `awsebcli` introduce un cambio que solo está permitido a partir de Python 3.12. Probablemente lo arreglen para soportar Python anteriores, pero podemos actualizar igualmente.

Fuente: https://github.com/aws/aws-elastic-beanstalk-cli/issues/558#issuecomment-2892496118